### PR TITLE
Fix typos and implement match method

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,14 +18,14 @@ func main() {
   hr := hostrouter.New()
 
   // Requests to api.domain.com
-  hr.Map("", apiRouter) // default
-  hr.Map("api.domain.com", apiRouter)
+  hr.Map("", apiRouter()) // default
+  hr.Map("api.domain.com", apiRouter())
 
   // Requests to doma.in
-  hr.Map("doma.in", shortUrlRouter)
+  hr.Map("doma.in", shortUrlRouter())
 
   // Requests to host that isn't defined above
-  hr.Map("*", everythingElseRouter)
+  hr.Map("*", everythingElseRouter())
 
   // Mount the host router
   r.Mount("/", hr)

--- a/hostrouter.go
+++ b/hostrouter.go
@@ -15,6 +15,10 @@ func New() Routes {
 	return Routes{}
 }
 
+func (hr Routes) Match(rctx *chi.Context, method, path string) bool {
+	return true
+}
+
 func (hr Routes) Map(host string, h chi.Router) {
 	hr[strings.ToLower(host)] = h
 }


### PR DESCRIPTION
Had an issue with match method not being implemented:
```
cannot use Routes literal (type Routes) as type chi.Routes in assignment:
        Routes does not implement chi.Routes (missing Match method)
```

Also fixed typos.