### PR TITLE
use hostname instead of host to remove ports

### DIFF
--- a/hostrouter.go
+++ b/hostrouter.go
@@ -63,7 +63,7 @@ func requestHost(r *http.Request) (host string) {
 	}
 
 	// if all else fails fall back to request host
-	host = r.Host
+	host = r.URL.Hostname()
 	return
 }
 


### PR DESCRIPTION
request.Host may include a portname, so it makes sense to ignore the port.