### PR TITLE
add support for wildcard subdomains

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ func main() {
   // Requests to doma.in
   hr.Map("doma.in", shortUrlRouter())
 
+  // Requests to *.doma.in
+  hr.Map("*.doma.in", shortUrlRouter())
+
   // Requests to host that isn't defined above
   hr.Map("*", everythingElseRouter())
 

--- a/hostrouter.go
+++ b/hostrouter.go
@@ -33,6 +33,10 @@ func (hr Routes) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		router.ServeHTTP(w, r)
 		return
 	}
+	if router, ok := hr[strings.ToLower(getWildcardHost(host))]; ok {
+		router.ServeHTTP(w, r)
+		return
+	}
 	if router, ok := hr["*"]; ok {
 		router.ServeHTTP(w, r)
 		return
@@ -88,4 +92,13 @@ func parseForwarded(forwarded string) (addr, proto, host string) {
 		}
 	}
 	return
+}
+
+func getWildcardHost(host string) string {
+	parts := strings.Split(host, ".")
+	if len(parts) > 1 {
+		wildcard := append([]string{"*"}, parts[1:]...)
+		return strings.Join(wildcard, ".")
+	}
+	return strings.Join(parts, ".")
 }

--- a/hostrouter_test.go
+++ b/hostrouter_test.go
@@ -1,0 +1,25 @@
+package hostrouter
+
+import "testing"
+
+func Test_getWildcardHost(t *testing.T) {
+	type args struct {
+		host string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{"no wildcard in 1-part host", args{"com"}, "com"},
+		{"wildcard in 2-part", args{"dot.com"}, "*.com"},
+		{"wildcard in 3-part", args{"amazing.dot.com"}, "*.dot.com"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getWildcardHost(tt.args.host); got != tt.want {
+				t.Errorf("getWildcardHost() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
as in the updated README: 

```go
  // Requests to *.doma.in
  hr.Map("*.doma.in", shortUrlRouter())
```

please let me know if this is something that was intentionally left out, for standards compliance or another reason. I'm happy to make any changes as need as well.

Thanks!