### PR TITLE
Add missing Find method

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/go-chi/hostrouter
 
 go 1.16
 
-require github.com/go-chi/chi/v5 v5.0.0
+require github.com/go-chi/chi/v5 v5.2.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/go-chi/chi/v5 v5.0.0 h1:DBPx88FjZJH3FsICfDAfIfnb7XxKIYVGG6lOPlhENAg=
-github.com/go-chi/chi/v5 v5.0.0/go.mod h1:BBug9lr0cqtdAhsu6R4AAdvufI0/XBzAQSsUqJpoZOs=
+github.com/go-chi/chi/v5 v5.2.0 h1:Aj1EtB0qR2Rdo2dG4O94RIU35w2lvQSj6BRA4+qwFL0=
+github.com/go-chi/chi/v5 v5.2.0/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=

--- a/hostrouter.go
+++ b/hostrouter.go
@@ -19,6 +19,10 @@ func (hr Routes) Match(rctx *chi.Context, method, path string) bool {
 	return true
 }
 
+func (hr Routes) Find(rctx *chi.Context, method, path string) string {
+	return ""
+}
+
 func (hr Routes) Map(host string, h chi.Router) {
 	hr[strings.ToLower(host)] = h
 }


### PR DESCRIPTION
This was added in https://github.com/go-chi/chi/pull/872 and is required to compile with `go-chi/chi` >= `v5.2.0`

Fixes https://github.com/go-chi/hostrouter/issues/9